### PR TITLE
enhancement: Add method for iterating over connected component sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ False
 >>> "a" in ds
 True
 
->>> list(self.dset)
+>>> list(ds)
 [(1, 2), (2, 2), (3, 3), ('a', 'a')]
+
+>>> list(ds.itersets())
+[{1, 2}, {3}, {'a'}]
+
 ```
 
 ## Contributing

--- a/disjoint_set/__init__.py
+++ b/disjoint_set/__init__.py
@@ -1,3 +1,4 @@
 from .main import DisjointSet
 
 name = "disjoint_set"
+__all__ = ['DisjointSet']

--- a/disjoint_set/main.py
+++ b/disjoint_set/main.py
@@ -35,7 +35,7 @@ class DisjointSet:
 
     def itersets(self) -> Generator[set, None, None]:
         """
-        Yields sets of connected components
+        Yields sets of connected components.
         >>> ds = DisjointSet()
         >>> ds.union(1,2)
         >>> list(ds.itersets())

--- a/disjoint_set/tests.py
+++ b/disjoint_set/tests.py
@@ -8,10 +8,12 @@ class TestDisjointSet(TestCase):
         self.dset = DisjointSet()
 
     def test_initializes_value_for_absent_key(self):
+        self.assertTrue(1 not in self.dset._data)
         self.assertEqual(
             self.dset.find(1),
-            1
+            1,
         )
+        self.assertTrue(1 in self.dset._data)
 
     def test_holds_and_compares_different_data_types(self):
         values = [
@@ -24,7 +26,20 @@ class TestDisjointSet(TestCase):
                 False,
             )
 
-    def test_unites_correctly(self):
+    def test_sets_the_same_class_for_united_elements(self):
+        self.assertNotEqual(
+            self.dset._data[1],
+            self.dset._data[2],
+        )
+
+        self.dset.union(1, 2)
+
+        self.assertEqual(
+            self.dset._data[1],
+            self.dset._data[2],
+        )
+
+    def test_unites_symmetrically(self):
         self.dset.union(1, 2)
         self.dset.union(3, 4)
         self.dset.union(1, 6)
@@ -40,7 +55,7 @@ class TestDisjointSet(TestCase):
             True,
         )
 
-    def test_finds_correctly(self):
+    def test_updates_class_assignment(self):
         self.dset.union(1, 2)
         self.dset.union(2, 3)
 
@@ -54,7 +69,7 @@ class TestDisjointSet(TestCase):
             3
         )
 
-    def test_contains_elements(self):
+    def test_contains_elements_returns_existing_keys(self):
         self.assertEqual(
             1 in self.dset,
             False,
@@ -92,4 +107,41 @@ class TestDisjointSet(TestCase):
         self.assertEqual(
             bool(self.dset),
             True,
+        )
+
+    def test_itersets_iterates_over_all_component_classes(self):
+        self.dset.union(1, 2)
+        self.dset.union(2, 3)
+        self.assertEqual(
+            list(self.dset.itersets()),
+            [{1, 2, 3}],
+        )
+        self.dset.union(4, 5)
+        self.assertEqual(
+            list(self.dset.itersets()),
+            [{1, 2, 3}, {4, 5}],
+        )
+
+    def refreshes_labels_if_forced(self):
+        self.dset.union(1, 2)
+        self.dset.union(2, 3)
+
+        self.assertEqual(
+            self.dset._data[1],
+            2,
+        )
+        self.assertEqual(
+            self.dset._data[2],
+            3,
+        )
+
+        self.dset._refresh_labels()
+
+        self.assertEqual(
+            self.dset._data[1],
+            2,
+        )
+        self.assertEqual(
+            self.dset._data[2],
+            3,
         )

--- a/disjoint_set/utils.py
+++ b/disjoint_set/utils.py
@@ -1,12 +1,15 @@
 from collections import defaultdict
+from typing import TypeVar, Callable
+
+T = TypeVar('T')
 
 
-class key_dependent_dict(defaultdict):
-    def __init__(self, fun_with_param):
+class ArgDefaultDict(defaultdict):
+    def __init__(self, fun_with_param: Callable[[T], T]):
         super().__init__(None)
-        self.fun = fun_with_param
+        self.fun: Callable[[T], T] = fun_with_param
 
-    def __missing__(self, key):
+    def __missing__(self, key: T) -> T:
         ret = self.fun(key)
         self[key] = ret
         return ret

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='disjoint_set',
-    version='0.5.0',
+    version='0.6.0',
     packages=setuptools.find_packages(),
     description='Disjoint set data structure implementation for Python',
     url='https://github.com/mrapacz/disjoint_set',


### PR DESCRIPTION
DisjointSet will now have a method for iterating over connected component sets
```python
>>> ds = DisjointSet()
>>> ds.union(1,2)
>>> list(ds.itersets())
[{1, 2}]
```

closes: #1 