### PR TITLE
Fix recursion

### DIFF
--- a/disjoint_set/main.py
+++ b/disjoint_set/main.py
@@ -44,6 +44,13 @@ class DisjointSet(Generic[T]):
         for element_class in element_classes.values():
             yield element_class
 
+    def _legacy_find(self, x: T) -> T:
+        import warnings
+        warnings.warn('might cause stack overflow; please use find() instead')
+        if x != self._data[x]:
+            self._data[x] = self.find(self._data[x])
+        return self._data[x]
+
     def find(self, x: T) -> T:
         """
         Returns the representative member of the set of connected components to which x belongs, may be x itself.
@@ -54,9 +61,15 @@ class DisjointSet(Generic[T]):
         >>> ds.find(1)
         2
         """
-        if x != self._data[x]:
-            self._data[x] = self.find(self._data[x])
-        return self._data[x]
+        # EACH node along the path should be pointed to the ROOT, instead of its DIRECT PARENT.
+        # see unittest case for detail
+        path = []
+        while x != self._data[x]:  # loop till the ROOT
+            path.append(x)
+            x = self._data[x]
+        for e in path:  # pointing EACH NODE directly to ROOT
+            self._data[e] = x
+        return x
 
     def union(self, x: T, y: T) -> None:
         """

--- a/disjoint_set/main.py
+++ b/disjoint_set/main.py
@@ -48,7 +48,7 @@ class DisjointSet(Generic[T]):
         import warnings
         warnings.warn('might cause stack overflow; please use find() instead')
         if x != self._data[x]:
-            self._data[x] = self.find(self._data[x])
+            self._data[x] = self._legacy_find(self._data[x])
         return self._data[x]
 
     def find(self, x: T) -> T:

--- a/test/test_disjoint_set.py
+++ b/test/test_disjoint_set.py
@@ -125,18 +125,24 @@ class TestDisjointSet(TestCase):
     def test_deep_recursion(self):
 
         def try_find(ds):
-            students = [{"school": "Stanford", "score": s} for s in range(1025)]
+            students = [("Stanford", s) for s in range(1025)]
             for i, s1 in enumerate(students):
                 for j, s2 in enumerate(students):
                     if i >= j: continue  # avoid duplicate connection
                     if ds.connected(s1, s2): continue  # skip if already connected
-                    if s1['school'] == s2['school']:
+                    if s1[0] == s2[0]:  # union student from same school, ignore their ID
                         ds.union(s1, s2)  # this would link s1 --> s2
+                pass
+            pass
 
         # using new find() should be OK
-        try_find(self.dset)
+        ds1 = disjoint_set.DisjointSet()
+        try_find(ds1)
 
         # using ._legacy_find() would cause stack overflow
-        self.dset.find = self.dset._legacy_find
-        with self.assertRaises(AssertionError):
-            try_find(self.dset)
+        import sys
+        sys.setrecursionlimit(1024)
+        ds2 = disjoint_set.DisjointSet()
+        ds2.find = ds2._legacy_find
+        with self.assertRaises(RecursionError):
+            try_find(ds2)

--- a/test/test_disjoint_set.py
+++ b/test/test_disjoint_set.py
@@ -123,9 +123,11 @@ class TestDisjointSet(TestCase):
         )
 
     def test_deep_recursion(self):
+        import sys
+        sys.setrecursionlimit(64)  # default limit for py3.7 is 3000
 
         def try_find(ds):
-            students = [("Stanford", s) for s in range(1025)]
+            students = [("Stanford", s) for s in range(65)]
             for i, s1 in enumerate(students):
                 for j, s2 in enumerate(students):
                     if i >= j: continue  # avoid duplicate connection
@@ -140,8 +142,6 @@ class TestDisjointSet(TestCase):
         try_find(ds1)
 
         # using ._legacy_find() would cause stack overflow
-        import sys
-        sys.setrecursionlimit(1024)
         ds2 = disjoint_set.DisjointSet()
         ds2.find = ds2._legacy_find
         with self.assertRaises(RecursionError):

--- a/test/test_disjoint_set.py
+++ b/test/test_disjoint_set.py
@@ -121,3 +121,22 @@ class TestDisjointSet(TestCase):
             list(self.dset.itersets()),
             [{1, 2, 3}, {4, 5}],
         )
+
+    def test_deep_recursion(self):
+
+        def try_find(ds):
+            students = [{"school": "Stanford", "score": s} for s in range(1025)]
+            for i, s1 in enumerate(students):
+                for j, s2 in enumerate(students):
+                    if i >= j: continue  # avoid duplicate connection
+                    if ds.connected(s1, s2): continue  # skip if already connected
+                    if s1['school'] == s2['school']:
+                        ds.union(s1, s2)  # this would link s1 --> s2
+
+        # using new find() should be OK
+        try_find(self.dset)
+
+        # using ._legacy_find() would cause stack overflow
+        self.dset.find = self.dset._legacy_find
+        with self.assertRaises(AssertionError):
+            try_find(self.dset)


### PR DESCRIPTION
Self recursion in `find()` cause stack overflow on some cases. Besides, it is more efficient to link all nodes along the path to root.