### PR TITLE
Add py.typed marker file to support type checking

### DIFF
--- a/disjoint_set/py.typed
+++ b/disjoint_set/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setuptools.setup(
     name='disjoint_set',
     version='0.6.1',
     packages=setuptools.find_packages(),
+    package_data={"disjoint_set": ["py.typed"]},
     description='Disjoint set data structure implementation for Python',
     url='https://github.com/mrapacz/disjoint_set',
     long_description=open('README.md').read(),


### PR DESCRIPTION
Even though all classes in the `disjoint_set` package come with type
annotations, projects which use `disjoint_set` installed from PyPI get
typing errors:

    $ python3 -m mypy --strict file.py
    file.py:5: error: Skipping analyzing 'disjoint_set': found module but no type hints or library stubs
    file.py:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports

According to PEP 561, a package which provides type hints must be marked
using a marker file named `py.typed` or otherwise it's considered not
typed. We add the missing file to the source and built distributions
which should fix the errors quoted above.