### PR TITLE
Add __len__ function

### DIFF
--- a/disjoint_set/main.py
+++ b/disjoint_set/main.py
@@ -72,6 +72,13 @@ class DisjointSet(Generic[T]):
             values=", ".join(str(dset) for dset in self.itersets()),
         )
 
+    def __len__(self) -> int:
+        i = 0
+        for key in self._data:
+            if key == self._data[key]:
+                i += 1
+        return i
+    
     def __iter__(self) -> Iterator[Tuple[T, T]]:
         """Iterate over items and their canonical elements."""
         try:


### PR DESCRIPTION
I just needed this function and quickly implemented it. I thought it might be helpful for the data structure.

My REPL:
```
>>> def len_d(self):
...   i = 0
...   for key in self._data:
...     if key == self._data[key]:
...       i += 1
...   return i
...
>>> DisjointSet.__len__ = len_d
>>> list(d.itersets())
[{1, 2}, {3}, {4}, {5}]
>>> len(d)
4
>>> d.union(3,4)
>>> list(d.itersets())
[{1, 2}, {3, 4}, {5}]
>>> len(d)
3
>>> d.union(5,4)
>>> list(d.itersets())
[{1, 2}, {3, 4, 5}]
>>> len(d)
2
```